### PR TITLE
Add TypeScript fal.ai example suite

### DIFF
--- a/examples/fal/typescript/.env.example
+++ b/examples/fal/typescript/.env.example
@@ -1,0 +1,1 @@
+FAL_KEY=your_fal_key_here

--- a/examples/fal/typescript/README.md
+++ b/examples/fal/typescript/README.md
@@ -1,0 +1,37 @@
+# FAL TypeScript Examples (x402/ACP compliant)
+
+## Quick start
+```bash
+pnpm i # or npm/yarn
+cp .env.example .env && edit .env
+pnpm --filter ./examples/fal/typescript build
+pnpm --filter ./examples/fal/typescript examples -- --slug <one-of-the-slugs-below>
+
+Available example slugs
+•fal-ai/flux-pro/kontext
+•fal-ai/flux/dev/image-to-image
+•fal-ai/flux-pro/v1.1-ultra
+•fal-ai/recraft/v3/text-to-image
+•fal-ai/kling-video/v2/master/image-to-video
+•fal-ai/wan-effects
+•fal-ai/kling-video/v2.5-turbo/pro/text-to-video
+•fal-ai/veo3/fast
+•bria/video/background-removal
+•fal-ai/mmaudio-v2
+•fal-ai/playai/tts/dialog
+•fal-ai/minimax-music/v1.5
+
+### File: `examples/fal/typescript/test/typecheck.test.ts`
+```ts
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+describe('typecheck only', () => {
+  it('generated files exist', () => {
+    const base = path.resolve(__dirname, '../src/generated');
+    assert.ok(fs.existsSync(base));
+  });
+});
+```

--- a/examples/fal/typescript/package.json
+++ b/examples/fal/typescript/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "fal-typescript-examples",
+  "private": true,
+  "type": "module",
+  "version": "0.1.0",
+  "scripts": {
+    "build": "tsc -p tsconfig.json --noEmit",
+    "examples": "ts-node src/index.ts",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
+  },
+  "dependencies": {
+    "@fal-ai/client": "^1.0.0",
+    "dotenv": "^16.4.5"
+  },
+  "devDependencies": {
+    "ts-node": "^10.9.2",
+    "typescript": "^5.4.0",
+    "@types/node": "^20.11.30"
+  }
+}

--- a/examples/fal/typescript/src/generated/image-to-image/fal-ai__flux-pro__kontext.ts
+++ b/examples/fal/typescript/src/generated/image-to-image/fal-ai__flux-pro__kontext.ts
@@ -1,0 +1,40 @@
+/**
+ * Model: FLUX.1 Kontext [pro] | Slug: fal-ai/flux-pro/kontext | Category: image-to-image | https://fal.ai/models/fal-ai/flux-pro/kontext
+ * 
+ */
+import 'dotenv/config';
+import { fal } from '@fal-ai/client';
+
+if (!process.env.FAL_KEY) {
+  throw new Error('Missing FAL_KEY. Copy .env.example to .env and set your key.');
+}
+fal.config({ credentials: process.env.FAL_KEY! });
+
+interface Input {
+  prompt: string;
+  image_url: string;
+}
+type Output = unknown;
+
+export async function run(customInput?: Partial<Input>) {
+  const input: Input = {
+    prompt: "Make the dress blue",
+    image_url: "https://example.com/input.jpg",
+    ...customInput
+  } as Input;
+
+  try {
+    const result: { data: Output } = await fal.subscribe('fal-ai/flux-pro/kontext', { input });
+    console.log(result.data);
+    return result.data;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error('FAL example failed:', message);
+    throw err;
+  }
+}
+
+async function main() {
+  await run();
+}
+if (import.meta.main) { void main(); }

--- a/examples/fal/typescript/src/generated/image-to-image/fal-ai__flux__dev__image-to-image.ts
+++ b/examples/fal/typescript/src/generated/image-to-image/fal-ai__flux__dev__image-to-image.ts
@@ -1,0 +1,40 @@
+/**
+ * Model: FLUX.1-dev image-to-image | Slug: fal-ai/flux/dev/image-to-image | Category: image-to-image | https://fal.ai/models/fal-ai/flux/dev/image-to-image
+ * 
+ */
+import 'dotenv/config';
+import { fal } from '@fal-ai/client';
+
+if (!process.env.FAL_KEY) {
+  throw new Error('Missing FAL_KEY. Copy .env.example to .env and set your key.');
+}
+fal.config({ credentials: process.env.FAL_KEY! });
+
+interface Input {
+  prompt: string;
+  image_url: string;
+}
+type Output = unknown;
+
+export async function run(customInput?: Partial<Input>) {
+  const input: Input = {
+    prompt: "Make the dress blue",
+    image_url: "https://example.com/input.jpg",
+    ...customInput
+  } as Input;
+
+  try {
+    const result: { data: Output } = await fal.subscribe('fal-ai/flux/dev/image-to-image', { input });
+    console.log(result.data);
+    return result.data;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error('FAL example failed:', message);
+    throw err;
+  }
+}
+
+async function main() {
+  await run();
+}
+if (import.meta.main) { void main(); }

--- a/examples/fal/typescript/src/generated/image-to-video/fal-ai__kling-video__v2__master__image-to-video.ts
+++ b/examples/fal/typescript/src/generated/image-to-video/fal-ai__kling-video__v2__master__image-to-video.ts
@@ -1,0 +1,40 @@
+/**
+ * Model: Kling Video v2 Master (Image-to-Video) | Slug: fal-ai/kling-video/v2/master/image-to-video | Category: image-to-video | https://fal.ai/models/fal-ai/kling-video/v2/master/image-to-video
+ * 
+ */
+import 'dotenv/config';
+import { fal } from '@fal-ai/client';
+
+if (!process.env.FAL_KEY) {
+  throw new Error('Missing FAL_KEY. Copy .env.example to .env and set your key.');
+}
+fal.config({ credentials: process.env.FAL_KEY! });
+
+interface Input {
+  prompt: string;
+  image_url: string;
+}
+type Output = unknown;
+
+export async function run(customInput?: Partial<Input>) {
+  const input: Input = {
+    prompt: "The whit...of determination",
+    image_url: "https://example.com/input.jpg",
+    ...customInput
+  } as Input;
+
+  try {
+    const result: { data: Output } = await fal.subscribe('fal-ai/kling-video/v2/master/image-to-video', { input });
+    console.log(result.data);
+    return result.data;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error('FAL example failed:', message);
+    throw err;
+  }
+}
+
+async function main() {
+  await run();
+}
+if (import.meta.main) { void main(); }

--- a/examples/fal/typescript/src/generated/image-to-video/fal-ai__wan-effects.ts
+++ b/examples/fal/typescript/src/generated/image-to-video/fal-ai__wan-effects.ts
@@ -1,0 +1,40 @@
+/**
+ * Model: Wan Effects (Image-to-Video) | Slug: fal-ai/wan-effects | Category: image-to-video | https://fal.ai/models/fal-ai/wan-effects
+ * 
+ */
+import 'dotenv/config';
+import { fal } from '@fal-ai/client';
+
+if (!process.env.FAL_KEY) {
+  throw new Error('Missing FAL_KEY. Copy .env.example to .env and set your key.');
+}
+fal.config({ credentials: process.env.FAL_KEY! });
+
+interface Input {
+  prompt: string;
+  image_url: string;
+}
+type Output = unknown;
+
+export async function run(customInput?: Partial<Input>) {
+  const input: Input = {
+    prompt: "The whit...of determination",
+    image_url: "https://example.com/input.jpg",
+    ...customInput
+  } as Input;
+
+  try {
+    const result: { data: Output } = await fal.subscribe('fal-ai/wan-effects', { input });
+    console.log(result.data);
+    return result.data;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error('FAL example failed:', message);
+    throw err;
+  }
+}
+
+async function main() {
+  await run();
+}
+if (import.meta.main) { void main(); }

--- a/examples/fal/typescript/src/generated/text-to-audio/fal-ai__minimax-music__v1.5.ts
+++ b/examples/fal/typescript/src/generated/text-to-audio/fal-ai__minimax-music__v1.5.ts
@@ -1,0 +1,38 @@
+/**
+ * Model: MiniMax Music v1.5 | Slug: fal-ai/minimax-music/v1.5 | Category: text-to-audio | https://fal.ai/models/fal-ai/minimax-music/v1.5
+ * 
+ */
+import 'dotenv/config';
+import { fal } from '@fal-ai/client';
+
+if (!process.env.FAL_KEY) {
+  throw new Error('Missing FAL_KEY. Copy .env.example to .env and set your key.');
+}
+fal.config({ credentials: process.env.FAL_KEY! });
+
+interface Input {
+  prompt: string;
+}
+type Output = unknown;
+
+export async function run(customInput?: Partial<Input>) {
+  const input: Input = {
+    prompt: "A beautiful sunset over the mountains",
+    ...customInput
+  } as Input;
+
+  try {
+    const result: { data: Output } = await fal.subscribe('fal-ai/minimax-music/v1.5', { input });
+    console.log(result.data);
+    return result.data;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error('FAL example failed:', message);
+    throw err;
+  }
+}
+
+async function main() {
+  await run();
+}
+if (import.meta.main) { void main(); }

--- a/examples/fal/typescript/src/generated/text-to-audio/fal-ai__playai__tts__dialog.ts
+++ b/examples/fal/typescript/src/generated/text-to-audio/fal-ai__playai__tts__dialog.ts
@@ -1,0 +1,38 @@
+/**
+ * Model: PlayAI TTS Dialog | Slug: fal-ai/playai/tts/dialog | Category: text-to-audio | https://fal.ai/models/fal-ai/playai/tts/dialog
+ * 
+ */
+import 'dotenv/config';
+import { fal } from '@fal-ai/client';
+
+if (!process.env.FAL_KEY) {
+  throw new Error('Missing FAL_KEY. Copy .env.example to .env and set your key.');
+}
+fal.config({ credentials: process.env.FAL_KEY! });
+
+interface Input {
+  prompt: string;
+}
+type Output = unknown;
+
+export async function run(customInput?: Partial<Input>) {
+  const input: Input = {
+    prompt: "A beautiful sunset over the mountains",
+    ...customInput
+  } as Input;
+
+  try {
+    const result: { data: Output } = await fal.subscribe('fal-ai/playai/tts/dialog', { input });
+    console.log(result.data);
+    return result.data;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error('FAL example failed:', message);
+    throw err;
+  }
+}
+
+async function main() {
+  await run();
+}
+if (import.meta.main) { void main(); }

--- a/examples/fal/typescript/src/generated/text-to-image/fal-ai__flux-pro__v1.1-ultra.ts
+++ b/examples/fal/typescript/src/generated/text-to-image/fal-ai__flux-pro__v1.1-ultra.ts
@@ -1,0 +1,38 @@
+/**
+ * Model: FLUX.1 [pro] v1.1 Ultra | Slug: fal-ai/flux-pro/v1.1-ultra | Category: text-to-image | https://fal.ai/models/fal-ai/flux-pro/v1.1-ultra
+ * 
+ */
+import 'dotenv/config';
+import { fal } from '@fal-ai/client';
+
+if (!process.env.FAL_KEY) {
+  throw new Error('Missing FAL_KEY. Copy .env.example to .env and set your key.');
+}
+fal.config({ credentials: process.env.FAL_KEY! });
+
+interface Input {
+  prompt: string;
+}
+type Output = unknown;
+
+export async function run(customInput?: Partial<Input>) {
+  const input: Input = {
+    prompt: "A beautiful sunset over the mountains",
+    ...customInput
+  } as Input;
+
+  try {
+    const result: { data: Output } = await fal.subscribe('fal-ai/flux-pro/v1.1-ultra', { input });
+    console.log(result.data);
+    return result.data;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error('FAL example failed:', message);
+    throw err;
+  }
+}
+
+async function main() {
+  await run();
+}
+if (import.meta.main) { void main(); }

--- a/examples/fal/typescript/src/generated/text-to-image/fal-ai__recraft__v3__text-to-image.ts
+++ b/examples/fal/typescript/src/generated/text-to-image/fal-ai__recraft__v3__text-to-image.ts
@@ -1,0 +1,38 @@
+/**
+ * Model: Recraft v3 Text-to-Image | Slug: fal-ai/recraft/v3/text-to-image | Category: text-to-image | https://fal.ai/models/fal-ai/recraft/v3/text-to-image
+ * 
+ */
+import 'dotenv/config';
+import { fal } from '@fal-ai/client';
+
+if (!process.env.FAL_KEY) {
+  throw new Error('Missing FAL_KEY. Copy .env.example to .env and set your key.');
+}
+fal.config({ credentials: process.env.FAL_KEY! });
+
+interface Input {
+  prompt: string;
+}
+type Output = unknown;
+
+export async function run(customInput?: Partial<Input>) {
+  const input: Input = {
+    prompt: "A beautiful sunset over the mountains",
+    ...customInput
+  } as Input;
+
+  try {
+    const result: { data: Output } = await fal.subscribe('fal-ai/recraft/v3/text-to-image', { input });
+    console.log(result.data);
+    return result.data;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error('FAL example failed:', message);
+    throw err;
+  }
+}
+
+async function main() {
+  await run();
+}
+if (import.meta.main) { void main(); }

--- a/examples/fal/typescript/src/generated/text-to-video/fal-ai__kling-video__v2.5-turbo__pro__text-to-video.ts
+++ b/examples/fal/typescript/src/generated/text-to-video/fal-ai__kling-video__v2.5-turbo__pro__text-to-video.ts
@@ -1,0 +1,38 @@
+/**
+ * Model: Kling Video v2.5 Turbo Pro (Text-to-Video) | Slug: fal-ai/kling-video/v2.5-turbo/pro/text-to-video | Category: text-to-video | https://fal.ai/models/fal-ai/kling-video/v2.5-turbo/pro/text-to-video
+ * 
+ */
+import 'dotenv/config';
+import { fal } from '@fal-ai/client';
+
+if (!process.env.FAL_KEY) {
+  throw new Error('Missing FAL_KEY. Copy .env.example to .env and set your key.');
+}
+fal.config({ credentials: process.env.FAL_KEY! });
+
+interface Input {
+  prompt: string;
+}
+type Output = unknown;
+
+export async function run(customInput?: Partial<Input>) {
+  const input: Input = {
+    prompt: "A beautiful sunset over the mountains",
+    ...customInput
+  } as Input;
+
+  try {
+    const result: { data: Output } = await fal.subscribe('fal-ai/kling-video/v2.5-turbo/pro/text-to-video', { input });
+    console.log(result.data);
+    return result.data;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error('FAL example failed:', message);
+    throw err;
+  }
+}
+
+async function main() {
+  await run();
+}
+if (import.meta.main) { void main(); }

--- a/examples/fal/typescript/src/generated/text-to-video/fal-ai__veo3__fast.ts
+++ b/examples/fal/typescript/src/generated/text-to-video/fal-ai__veo3__fast.ts
@@ -1,0 +1,38 @@
+/**
+ * Model: Veo 3 Fast (Text-to-Video) | Slug: fal-ai/veo3/fast | Category: text-to-video | https://fal.ai/models/fal-ai/veo3/fast
+ * 
+ */
+import 'dotenv/config';
+import { fal } from '@fal-ai/client';
+
+if (!process.env.FAL_KEY) {
+  throw new Error('Missing FAL_KEY. Copy .env.example to .env and set your key.');
+}
+fal.config({ credentials: process.env.FAL_KEY! });
+
+interface Input {
+  prompt: string;
+}
+type Output = unknown;
+
+export async function run(customInput?: Partial<Input>) {
+  const input: Input = {
+    prompt: "A beautiful sunset over the mountains",
+    ...customInput
+  } as Input;
+
+  try {
+    const result: { data: Output } = await fal.subscribe('fal-ai/veo3/fast', { input });
+    console.log(result.data);
+    return result.data;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error('FAL example failed:', message);
+    throw err;
+  }
+}
+
+async function main() {
+  await run();
+}
+if (import.meta.main) { void main(); }

--- a/examples/fal/typescript/src/generated/video-to-video/bria__video__background-removal.ts
+++ b/examples/fal/typescript/src/generated/video-to-video/bria__video__background-removal.ts
@@ -1,0 +1,40 @@
+/**
+ * Model: Bria Video Background Removal | Slug: bria/video/background-removal | Category: video-to-video | https://fal.ai/models/bria/video/background-removal
+ * 
+ */
+import 'dotenv/config';
+import { fal } from '@fal-ai/client';
+
+if (!process.env.FAL_KEY) {
+  throw new Error('Missing FAL_KEY. Copy .env.example to .env and set your key.');
+}
+fal.config({ credentials: process.env.FAL_KEY! });
+
+interface Input {
+  prompt: string;
+  image_url: string;
+}
+type Output = unknown;
+
+export async function run(customInput?: Partial<Input>) {
+  const input: Input = {
+    prompt: "The whit...of determination",
+    image_url: "https://example.com/input.jpg",
+    ...customInput
+  } as Input;
+
+  try {
+    const result: { data: Output } = await fal.subscribe('bria/video/background-removal', { input });
+    console.log(result.data);
+    return result.data;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error('FAL example failed:', message);
+    throw err;
+  }
+}
+
+async function main() {
+  await run();
+}
+if (import.meta.main) { void main(); }

--- a/examples/fal/typescript/src/generated/video-to-video/fal-ai__mmaudio-v2.ts
+++ b/examples/fal/typescript/src/generated/video-to-video/fal-ai__mmaudio-v2.ts
@@ -1,0 +1,40 @@
+/**
+ * Model: MMAudio v2 (Video-to-Video) | Slug: fal-ai/mmaudio-v2 | Category: video-to-video | https://fal.ai/models/fal-ai/mmaudio-v2
+ * 
+ */
+import 'dotenv/config';
+import { fal } from '@fal-ai/client';
+
+if (!process.env.FAL_KEY) {
+  throw new Error('Missing FAL_KEY. Copy .env.example to .env and set your key.');
+}
+fal.config({ credentials: process.env.FAL_KEY! });
+
+interface Input {
+  prompt: string;
+  image_url: string;
+}
+type Output = unknown;
+
+export async function run(customInput?: Partial<Input>) {
+  const input: Input = {
+    prompt: "The whit...of determination",
+    image_url: "https://example.com/input.jpg",
+    ...customInput
+  } as Input;
+
+  try {
+    const result: { data: Output } = await fal.subscribe('fal-ai/mmaudio-v2', { input });
+    console.log(result.data);
+    return result.data;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error('FAL example failed:', message);
+    throw err;
+  }
+}
+
+async function main() {
+  await run();
+}
+if (import.meta.main) { void main(); }

--- a/examples/fal/typescript/src/index.ts
+++ b/examples/fal/typescript/src/index.ts
@@ -1,0 +1,64 @@
+import 'dotenv/config';
+import * as fal_ai__flux_pro__kontext from './generated/image-to-image/fal-ai__flux-pro__kontext.ts';
+import * as fal_ai__flux__dev__image_to_image from './generated/image-to-image/fal-ai__flux__dev__image-to-image.ts';
+import * as fal_ai__flux_pro__v1_1_ultra from './generated/text-to-image/fal-ai__flux-pro__v1.1-ultra.ts';
+import * as fal_ai__recraft__v3__text_to_image from './generated/text-to-image/fal-ai__recraft__v3__text-to-image.ts';
+import * as fal_ai__kling_video__v2__master__image_to_video from './generated/image-to-video/fal-ai__kling-video__v2__master__image-to-video.ts';
+import * as fal_ai__wan_effects from './generated/image-to-video/fal-ai__wan-effects.ts';
+import * as fal_ai__kling_video__v2_5_turbo__pro__text_to_video from './generated/text-to-video/fal-ai__kling-video__v2.5-turbo__pro__text-to-video.ts';
+import * as fal_ai__veo3__fast from './generated/text-to-video/fal-ai__veo3__fast.ts';
+import * as bria__video__background_removal from './generated/video-to-video/bria__video__background-removal.ts';
+import * as fal_ai__mmaudio_v2 from './generated/video-to-video/fal-ai__mmaudio-v2.ts';
+import * as fal_ai__playai__tts__dialog from './generated/text-to-audio/fal-ai__playai__tts__dialog.ts';
+import * as fal_ai__minimax_music__v1_5 from './generated/text-to-audio/fal-ai__minimax-music__v1.5.ts';
+
+type Runner = (customInput?: Record<string, unknown>) => Promise<unknown>;
+
+const registry = new Map<string, Runner>([
+    ['fal-ai/flux-pro/kontext', fal_ai__flux_pro__kontext.run], // image-to-image
+    ['fal-ai/flux/dev/image-to-image', fal_ai__flux__dev__image_to_image.run], // image-to-image
+    ['fal-ai/flux-pro/v1.1-ultra', fal_ai__flux_pro__v1_1_ultra.run], // text-to-image
+    ['fal-ai/recraft/v3/text-to-image', fal_ai__recraft__v3__text_to_image.run], // text-to-image
+    ['fal-ai/kling-video/v2/master/image-to-video', fal_ai__kling_video__v2__master__image_to_video.run], // image-to-video
+    ['fal-ai/wan-effects', fal_ai__wan_effects.run], // image-to-video
+    ['fal-ai/kling-video/v2.5-turbo/pro/text-to-video', fal_ai__kling_video__v2_5_turbo__pro__text_to_video.run], // text-to-video
+    ['fal-ai/veo3/fast', fal_ai__veo3__fast.run], // text-to-video
+    ['bria/video/background-removal', bria__video__background_removal.run], // video-to-video
+    ['fal-ai/mmaudio-v2', fal_ai__mmaudio_v2.run], // video-to-video
+    ['fal-ai/playai/tts/dialog', fal_ai__playai__tts__dialog.run], // text-to-audio
+    ['fal-ai/minimax-music/v1.5', fal_ai__minimax_music__v1_5.run] // text-to-audio
+]);
+
+function help() {
+  console.log('Usage: ts-node src/index.ts --slug <slug>');
+  console.log('Available slugs:');
+  for (const [slug] of registry) {
+    console.log('  -', slug);
+  }
+}
+
+async function main() {
+  const args = new Map<string, string>();
+  for (let i=2; i<process.argv.length; i+=2) {
+    args.set(process.argv[i], process.argv[i+1]);
+  }
+  const slug = args.get('--slug');
+  if (!slug) {
+    help();
+    process.exit(1);
+  }
+  const run = registry.get(slug);
+  if (!run) {
+    console.error('Unknown slug:', slug);
+    help();
+    process.exit(1);
+  }
+  const result = await run();
+  if (result !== undefined) {
+    console.log(JSON.stringify(result, null, 2));
+  }
+}
+
+if (import.meta.main) {
+  void main();
+}

--- a/examples/fal/typescript/test/typecheck.test.ts
+++ b/examples/fal/typescript/test/typecheck.test.ts
@@ -1,0 +1,11 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+describe('typecheck only', () => {
+  it('generated files exist', () => {
+    const base = path.resolve(__dirname, '../src/generated');
+    assert.ok(fs.existsSync(base));
+  });
+});

--- a/examples/fal/typescript/tsconfig.json
+++ b/examples/fal/typescript/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts"]
+}


### PR DESCRIPTION
<!-- x402: deterministic structure & naming, strict TS types, idempotent file writes. -->
<!-- ACP: no secrets in source; FAL_KEY must come from env; minimal logging; network only to FAL during explicit runs. -->
## Summary
- scaffold a TypeScript example workspace under examples/fal/typescript with strict compiler configuration and package metadata
- add a CLI registry that routes model slugs to generated fal.ai runners for image, video, and audio categories
- document setup and include a smoke test to assert generated module presence alongside twelve curated runner modules

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68faa6eab094832fb5d09ff20264a53c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced TypeScript examples for Fal AI services, demonstrating image-to-image, text-to-image, image-to-video, text-to-video, video-to-video, and text-to-audio pipelines through a CLI tool.

* **Documentation**
  * Added quick start guide with setup and build instructions for the TypeScript examples.

* **Tests**
  * Added verification tests to validate example integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->