### PR TITLE
Rename TypeScript fal examples to WZRDTech

### DIFF
--- a/examples/wzrdtech/typescript/.env.example
+++ b/examples/wzrdtech/typescript/.env.example
@@ -1,0 +1,1 @@
+FAL_KEY=your_fal_key_here

--- a/examples/wzrdtech/typescript/README.md
+++ b/examples/wzrdtech/typescript/README.md
@@ -1,0 +1,57 @@
+# WZRDTech TypeScript Examples (x402/ACP compliant)
+
+## Quick start
+```bash
+pnpm i # or npm/yarn
+cp .env.example .env && edit .env
+pnpm --filter ./examples/wzrdtech/typescript build
+pnpm --filter ./examples/wzrdtech/typescript examples -- --slug <one-of-the-slugs-below>
+
+Available example slugs
+- fal-ai/flux-pro/kontext
+- fal-ai/flux/dev/image-to-image
+- fal-ai/flux-pro/v1.1-ultra
+- fal-ai/recraft/v3/text-to-image
+- fal-ai/kling-video/v2/master/image-to-video
+- fal-ai/wan-effects
+- fal-ai/kling-video/v2.5-turbo/pro/text-to-video
+- fal-ai/veo3/fast
+- fal-ai/wan-pro/image-to-video
+- fal-ai/veo2/image-to-video
+- fal-ai/kling-video/v1.6/pro/image-to-video
+- fal-ai/minimax/video-01/image-to-video
+- fal-ai/wan-25-preview/image-to-video
+- fal-ai/kling-video/v2.5-turbo/pro/image-to-video
+- fal-ai/flux-krea-trainer
+- fal-ai/flux-kontext-trainer
+- fal-ai/minimax/hailuo-02/standard/image-to-video
+- fal-ai/minimax/hailuo-02/standard/text-to-video
+- bria/text-to-image/3.2
+- fal-ai/bytedance/seedance/v1/pro/image-to-video
+- fal-ai/imagen4/preview/fast
+- fal-ai/veo3
+- fal-ai/kling-video/v2.1/master/image-to-video
+- fal-ai/kling-video/v2.1/image-to-video
+- fal-ai/imagen4
+- fal-ai/kling-video/v2.0/master/text-to-video
+- fal-ai/hidream/i1/full
+- fal-ai/hidream/i1/dev
+- bria/video/background-removal
+- fal-ai/mmaudio-v2
+- fal-ai/playai/tts/dialog
+- fal-ai/minimax-music/v1.5
+
+### File: `examples/wzrdtech/typescript/test/typecheck.test.ts`
+```ts
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+describe('typecheck only', () => {
+  it('generated files exist', () => {
+    const base = path.resolve(__dirname, '../src/generated');
+    assert.ok(fs.existsSync(base));
+  });
+});
+```

--- a/examples/wzrdtech/typescript/package.json
+++ b/examples/wzrdtech/typescript/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "wzrdtech-typescript-examples",
+  "private": true,
+  "type": "module",
+  "version": "0.1.0",
+  "scripts": {
+    "build": "tsc -p tsconfig.json --noEmit",
+    "examples": "ts-node src/index.ts",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
+  },
+  "dependencies": {
+    "@fal-ai/client": "^1.0.0",
+    "dotenv": "^16.4.5"
+  },
+  "devDependencies": {
+    "ts-node": "^10.9.2",
+    "typescript": "^5.4.0",
+    "@types/node": "^20.11.30"
+  }
+}

--- a/examples/wzrdtech/typescript/src/generated/image-to-image/fal-ai__flux-pro__kontext.ts
+++ b/examples/wzrdtech/typescript/src/generated/image-to-image/fal-ai__flux-pro__kontext.ts
@@ -1,0 +1,40 @@
+/**
+ * Model: FLUX.1 Kontext [pro] | Slug: fal-ai/flux-pro/kontext | Category: image-to-image | https://fal.ai/models/fal-ai/flux-pro/kontext
+ * 
+ */
+import 'dotenv/config';
+import { fal } from '@fal-ai/client';
+
+if (!process.env.FAL_KEY) {
+  throw new Error('Missing FAL_KEY. Copy .env.example to .env and set your key.');
+}
+fal.config({ credentials: process.env.FAL_KEY! });
+
+interface Input {
+  prompt: string;
+  image_url: string;
+}
+type Output = unknown;
+
+export async function run(customInput?: Partial<Input>) {
+  const input: Input = {
+    prompt: "Make the dress blue",
+    image_url: "https://example.com/input.jpg",
+    ...customInput
+  } as Input;
+
+  try {
+    const result: { data: Output } = await fal.subscribe('fal-ai/flux-pro/kontext', { input });
+    console.log(result.data);
+    return result.data;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error('FAL example failed:', message);
+    throw err;
+  }
+}
+
+async function main() {
+  await run();
+}
+if (import.meta.main) { void main(); }

--- a/examples/wzrdtech/typescript/src/generated/image-to-image/fal-ai__flux__dev__image-to-image.ts
+++ b/examples/wzrdtech/typescript/src/generated/image-to-image/fal-ai__flux__dev__image-to-image.ts
@@ -1,0 +1,40 @@
+/**
+ * Model: FLUX.1-dev image-to-image | Slug: fal-ai/flux/dev/image-to-image | Category: image-to-image | https://fal.ai/models/fal-ai/flux/dev/image-to-image
+ * 
+ */
+import 'dotenv/config';
+import { fal } from '@fal-ai/client';
+
+if (!process.env.FAL_KEY) {
+  throw new Error('Missing FAL_KEY. Copy .env.example to .env and set your key.');
+}
+fal.config({ credentials: process.env.FAL_KEY! });
+
+interface Input {
+  prompt: string;
+  image_url: string;
+}
+type Output = unknown;
+
+export async function run(customInput?: Partial<Input>) {
+  const input: Input = {
+    prompt: "Make the dress blue",
+    image_url: "https://example.com/input.jpg",
+    ...customInput
+  } as Input;
+
+  try {
+    const result: { data: Output } = await fal.subscribe('fal-ai/flux/dev/image-to-image', { input });
+    console.log(result.data);
+    return result.data;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error('FAL example failed:', message);
+    throw err;
+  }
+}
+
+async function main() {
+  await run();
+}
+if (import.meta.main) { void main(); }

--- a/examples/wzrdtech/typescript/src/generated/image-to-video/fal-ai__bytedance__seedance__v1__pro__image-to-video.ts
+++ b/examples/wzrdtech/typescript/src/generated/image-to-video/fal-ai__bytedance__seedance__v1__pro__image-to-video.ts
@@ -1,0 +1,40 @@
+/**
+ * Model: Seedance 1.0 Pro | Slug: fal-ai/bytedance/seedance/v1/pro/image-to-video | Category: image-to-video | https://fal.ai/models/fal-ai/bytedance/seedance/v1/pro/image-to-video
+ * ByteDance Seedance Pro converts single images into cinematic motions with strong temporal coherence.
+ */
+import 'dotenv/config';
+import { fal } from '@fal-ai/client';
+
+if (!process.env.FAL_KEY) {
+  throw new Error('Missing FAL_KEY. Copy .env.example to .env and set your key.');
+}
+fal.config({ credentials: process.env.FAL_KEY! });
+
+interface Input {
+  prompt: string;
+  image_url: string;
+}
+type Output = unknown;
+
+export async function run(customInput?: Partial<Input>) {
+  const input: Input = {
+    prompt: "The whit...of determination",
+    image_url: "https://example.com/input.jpg",
+    ...customInput
+  } as Input;
+
+  try {
+    const result: { data: Output } = await fal.subscribe('fal-ai/bytedance/seedance/v1/pro/image-to-video', { input });
+    console.log(result.data);
+    return result.data;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error('FAL example failed:', message);
+    throw err;
+  }
+}
+
+async function main() {
+  await run();
+}
+if (import.meta.main) { void main(); }

--- a/examples/wzrdtech/typescript/src/generated/image-to-video/fal-ai__kling-video__v1.6__pro__image-to-video.ts
+++ b/examples/wzrdtech/typescript/src/generated/image-to-video/fal-ai__kling-video__v1.6__pro__image-to-video.ts
@@ -1,0 +1,40 @@
+/**
+ * Model: Kling 2.0 Pro | Slug: fal-ai/kling-video/v1.6/pro/image-to-video | Category: image-to-video | https://fal.ai/models/fal-ai/kling-video/v1.6/pro/image-to-video
+ * Generate high fidelity videos from still images using Kling 2.0 Pro’s advanced motion synthesis.
+ */
+import 'dotenv/config';
+import { fal } from '@fal-ai/client';
+
+if (!process.env.FAL_KEY) {
+  throw new Error('Missing FAL_KEY. Copy .env.example to .env and set your key.');
+}
+fal.config({ credentials: process.env.FAL_KEY! });
+
+interface Input {
+  prompt: string;
+  image_url: string;
+}
+type Output = unknown;
+
+export async function run(customInput?: Partial<Input>) {
+  const input: Input = {
+    prompt: "The whit...of determination",
+    image_url: "https://example.com/input.jpg",
+    ...customInput
+  } as Input;
+
+  try {
+    const result: { data: Output } = await fal.subscribe('fal-ai/kling-video/v1.6/pro/image-to-video', { input });
+    console.log(result.data);
+    return result.data;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error('FAL example failed:', message);
+    throw err;
+  }
+}
+
+async function main() {
+  await run();
+}
+if (import.meta.main) { void main(); }

--- a/examples/wzrdtech/typescript/src/generated/image-to-video/fal-ai__kling-video__v2.1__image-to-video.ts
+++ b/examples/wzrdtech/typescript/src/generated/image-to-video/fal-ai__kling-video__v2.1__image-to-video.ts
@@ -1,0 +1,40 @@
+/**
+ * Model: Kling 2.1 (standard) | Slug: fal-ai/kling-video/v2.1/image-to-video | Category: image-to-video | https://fal.ai/models/fal-ai/kling-video/v2.1/image-to-video
+ * Standard Kling 2.1 image-to-video for balanced speed and quality.
+ */
+import 'dotenv/config';
+import { fal } from '@fal-ai/client';
+
+if (!process.env.FAL_KEY) {
+  throw new Error('Missing FAL_KEY. Copy .env.example to .env and set your key.');
+}
+fal.config({ credentials: process.env.FAL_KEY! });
+
+interface Input {
+  prompt: string;
+  image_url: string;
+}
+type Output = unknown;
+
+export async function run(customInput?: Partial<Input>) {
+  const input: Input = {
+    prompt: "The whit...of determination",
+    image_url: "https://example.com/input.jpg",
+    ...customInput
+  } as Input;
+
+  try {
+    const result: { data: Output } = await fal.subscribe('fal-ai/kling-video/v2.1/image-to-video', { input });
+    console.log(result.data);
+    return result.data;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error('FAL example failed:', message);
+    throw err;
+  }
+}
+
+async function main() {
+  await run();
+}
+if (import.meta.main) { void main(); }

--- a/examples/wzrdtech/typescript/src/generated/image-to-video/fal-ai__kling-video__v2.1__master__image-to-video.ts
+++ b/examples/wzrdtech/typescript/src/generated/image-to-video/fal-ai__kling-video__v2.1__master__image-to-video.ts
@@ -1,0 +1,40 @@
+/**
+ * Model: Kling 2.1 Master | Slug: fal-ai/kling-video/v2.1/master/image-to-video | Category: image-to-video | https://fal.ai/models/fal-ai/kling-video/v2.1/master/image-to-video
+ * Master-quality Kling 2.1 image-to-video with enhanced realism and dynamics.
+ */
+import 'dotenv/config';
+import { fal } from '@fal-ai/client';
+
+if (!process.env.FAL_KEY) {
+  throw new Error('Missing FAL_KEY. Copy .env.example to .env and set your key.');
+}
+fal.config({ credentials: process.env.FAL_KEY! });
+
+interface Input {
+  prompt: string;
+  image_url: string;
+}
+type Output = unknown;
+
+export async function run(customInput?: Partial<Input>) {
+  const input: Input = {
+    prompt: "The whit...of determination",
+    image_url: "https://example.com/input.jpg",
+    ...customInput
+  } as Input;
+
+  try {
+    const result: { data: Output } = await fal.subscribe('fal-ai/kling-video/v2.1/master/image-to-video', { input });
+    console.log(result.data);
+    return result.data;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error('FAL example failed:', message);
+    throw err;
+  }
+}
+
+async function main() {
+  await run();
+}
+if (import.meta.main) { void main(); }

--- a/examples/wzrdtech/typescript/src/generated/image-to-video/fal-ai__kling-video__v2.5-turbo__pro__image-to-video.ts
+++ b/examples/wzrdtech/typescript/src/generated/image-to-video/fal-ai__kling-video__v2.5-turbo__pro__image-to-video.ts
@@ -1,0 +1,40 @@
+/**
+ * Model: Kling Video v2.5 Turbo Pro (Image to Video) | Slug: fal-ai/kling-video/v2.5-turbo/pro/image-to-video | Category: image-to-video | https://fal.ai/models/fal-ai/kling-video/v2.5-turbo/pro/image-to-video
+ * High-speed, high-quality conversion from image to video using Kling v2.5 Turbo Pro.
+ */
+import 'dotenv/config';
+import { fal } from '@fal-ai/client';
+
+if (!process.env.FAL_KEY) {
+  throw new Error('Missing FAL_KEY. Copy .env.example to .env and set your key.');
+}
+fal.config({ credentials: process.env.FAL_KEY! });
+
+interface Input {
+  prompt: string;
+  image_url: string;
+}
+type Output = unknown;
+
+export async function run(customInput?: Partial<Input>) {
+  const input: Input = {
+    prompt: "The whit...of determination",
+    image_url: "https://example.com/input.jpg",
+    ...customInput
+  } as Input;
+
+  try {
+    const result: { data: Output } = await fal.subscribe('fal-ai/kling-video/v2.5-turbo/pro/image-to-video', { input });
+    console.log(result.data);
+    return result.data;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error('FAL example failed:', message);
+    throw err;
+  }
+}
+
+async function main() {
+  await run();
+}
+if (import.meta.main) { void main(); }

--- a/examples/wzrdtech/typescript/src/generated/image-to-video/fal-ai__kling-video__v2__master__image-to-video.ts
+++ b/examples/wzrdtech/typescript/src/generated/image-to-video/fal-ai__kling-video__v2__master__image-to-video.ts
@@ -1,0 +1,40 @@
+/**
+ * Model: Kling Video v2 Master (Image-to-Video) | Slug: fal-ai/kling-video/v2/master/image-to-video | Category: image-to-video | https://fal.ai/models/fal-ai/kling-video/v2/master/image-to-video
+ * 
+ */
+import 'dotenv/config';
+import { fal } from '@fal-ai/client';
+
+if (!process.env.FAL_KEY) {
+  throw new Error('Missing FAL_KEY. Copy .env.example to .env and set your key.');
+}
+fal.config({ credentials: process.env.FAL_KEY! });
+
+interface Input {
+  prompt: string;
+  image_url: string;
+}
+type Output = unknown;
+
+export async function run(customInput?: Partial<Input>) {
+  const input: Input = {
+    prompt: "The whit...of determination",
+    image_url: "https://example.com/input.jpg",
+    ...customInput
+  } as Input;
+
+  try {
+    const result: { data: Output } = await fal.subscribe('fal-ai/kling-video/v2/master/image-to-video', { input });
+    console.log(result.data);
+    return result.data;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error('FAL example failed:', message);
+    throw err;
+  }
+}
+
+async function main() {
+  await run();
+}
+if (import.meta.main) { void main(); }

--- a/examples/wzrdtech/typescript/src/generated/image-to-video/fal-ai__minimax__hailuo-02__standard__image-to-video.ts
+++ b/examples/wzrdtech/typescript/src/generated/image-to-video/fal-ai__minimax__hailuo-02__standard__image-to-video.ts
@@ -1,0 +1,40 @@
+/**
+ * Model: MiniMax Hailuo 02 [Standard] (Image to Video) | Slug: fal-ai/minimax/hailuo-02/standard/image-to-video | Category: image-to-video | https://fal.ai/models/fal-ai/minimax/hailuo-02/standard/image-to-video
+ * Hailuo 02 (Standard) generates expressive motion from a single image while maintaining subject identity.
+ */
+import 'dotenv/config';
+import { fal } from '@fal-ai/client';
+
+if (!process.env.FAL_KEY) {
+  throw new Error('Missing FAL_KEY. Copy .env.example to .env and set your key.');
+}
+fal.config({ credentials: process.env.FAL_KEY! });
+
+interface Input {
+  prompt: string;
+  image_url: string;
+}
+type Output = unknown;
+
+export async function run(customInput?: Partial<Input>) {
+  const input: Input = {
+    prompt: "The whit...of determination",
+    image_url: "https://example.com/input.jpg",
+    ...customInput
+  } as Input;
+
+  try {
+    const result: { data: Output } = await fal.subscribe('fal-ai/minimax/hailuo-02/standard/image-to-video', { input });
+    console.log(result.data);
+    return result.data;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error('FAL example failed:', message);
+    throw err;
+  }
+}
+
+async function main() {
+  await run();
+}
+if (import.meta.main) { void main(); }

--- a/examples/wzrdtech/typescript/src/generated/image-to-video/fal-ai__minimax__video-01__image-to-video.ts
+++ b/examples/wzrdtech/typescript/src/generated/image-to-video/fal-ai__minimax__video-01__image-to-video.ts
@@ -1,0 +1,40 @@
+/**
+ * Model: MiniMax Video-01 (Image to Video) | Slug: fal-ai/minimax/video-01/image-to-video | Category: image-to-video | https://fal.ai/models/fal-ai/minimax/video-01/image-to-video
+ * MiniMax Video-01 generates coherent motion from a single reference image with strong temporal consistency.
+ */
+import 'dotenv/config';
+import { fal } from '@fal-ai/client';
+
+if (!process.env.FAL_KEY) {
+  throw new Error('Missing FAL_KEY. Copy .env.example to .env and set your key.');
+}
+fal.config({ credentials: process.env.FAL_KEY! });
+
+interface Input {
+  prompt: string;
+  image_url: string;
+}
+type Output = unknown;
+
+export async function run(customInput?: Partial<Input>) {
+  const input: Input = {
+    prompt: "The whit...of determination",
+    image_url: "https://example.com/input.jpg",
+    ...customInput
+  } as Input;
+
+  try {
+    const result: { data: Output } = await fal.subscribe('fal-ai/minimax/video-01/image-to-video', { input });
+    console.log(result.data);
+    return result.data;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error('FAL example failed:', message);
+    throw err;
+  }
+}
+
+async function main() {
+  await run();
+}
+if (import.meta.main) { void main(); }

--- a/examples/wzrdtech/typescript/src/generated/image-to-video/fal-ai__veo2__image-to-video.ts
+++ b/examples/wzrdtech/typescript/src/generated/image-to-video/fal-ai__veo2__image-to-video.ts
@@ -1,0 +1,40 @@
+/**
+ * Model: Veo 2 (Image to Video) | Slug: fal-ai/veo2/image-to-video | Category: image-to-video | https://fal.ai/models/fal-ai/veo2/image-to-video
+ * Veo 2 creates videos from images with realistic motion and transitions while preserving the input composition.
+ */
+import 'dotenv/config';
+import { fal } from '@fal-ai/client';
+
+if (!process.env.FAL_KEY) {
+  throw new Error('Missing FAL_KEY. Copy .env.example to .env and set your key.');
+}
+fal.config({ credentials: process.env.FAL_KEY! });
+
+interface Input {
+  prompt: string;
+  image_url: string;
+}
+type Output = unknown;
+
+export async function run(customInput?: Partial<Input>) {
+  const input: Input = {
+    prompt: "The whit...of determination",
+    image_url: "https://example.com/input.jpg",
+    ...customInput
+  } as Input;
+
+  try {
+    const result: { data: Output } = await fal.subscribe('fal-ai/veo2/image-to-video', { input });
+    console.log(result.data);
+    return result.data;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error('FAL example failed:', message);
+    throw err;
+  }
+}
+
+async function main() {
+  await run();
+}
+if (import.meta.main) { void main(); }

--- a/examples/wzrdtech/typescript/src/generated/image-to-video/fal-ai__wan-25-preview__image-to-video.ts
+++ b/examples/wzrdtech/typescript/src/generated/image-to-video/fal-ai__wan-25-preview__image-to-video.ts
@@ -1,0 +1,40 @@
+/**
+ * Model: Wan 2.5 Image to Video | Slug: fal-ai/wan-25-preview/image-to-video | Category: image-to-video | https://fal.ai/models/fal-ai/wan-25-preview/image-to-video
+ * Create videos from single images with Wan 2.5’s preview tier, offering balanced speed and quality.
+ */
+import 'dotenv/config';
+import { fal } from '@fal-ai/client';
+
+if (!process.env.FAL_KEY) {
+  throw new Error('Missing FAL_KEY. Copy .env.example to .env and set your key.');
+}
+fal.config({ credentials: process.env.FAL_KEY! });
+
+interface Input {
+  prompt: string;
+  image_url: string;
+}
+type Output = unknown;
+
+export async function run(customInput?: Partial<Input>) {
+  const input: Input = {
+    prompt: "The whit...of determination",
+    image_url: "https://example.com/input.jpg",
+    ...customInput
+  } as Input;
+
+  try {
+    const result: { data: Output } = await fal.subscribe('fal-ai/wan-25-preview/image-to-video', { input });
+    console.log(result.data);
+    return result.data;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error('FAL example failed:', message);
+    throw err;
+  }
+}
+
+async function main() {
+  await run();
+}
+if (import.meta.main) { void main(); }

--- a/examples/wzrdtech/typescript/src/generated/image-to-video/fal-ai__wan-effects.ts
+++ b/examples/wzrdtech/typescript/src/generated/image-to-video/fal-ai__wan-effects.ts
@@ -1,0 +1,40 @@
+/**
+ * Model: Wan Effects (Image-to-Video) | Slug: fal-ai/wan-effects | Category: image-to-video | https://fal.ai/models/fal-ai/wan-effects
+ * 
+ */
+import 'dotenv/config';
+import { fal } from '@fal-ai/client';
+
+if (!process.env.FAL_KEY) {
+  throw new Error('Missing FAL_KEY. Copy .env.example to .env and set your key.');
+}
+fal.config({ credentials: process.env.FAL_KEY! });
+
+interface Input {
+  prompt: string;
+  image_url: string;
+}
+type Output = unknown;
+
+export async function run(customInput?: Partial<Input>) {
+  const input: Input = {
+    prompt: "The whit...of determination",
+    image_url: "https://example.com/input.jpg",
+    ...customInput
+  } as Input;
+
+  try {
+    const result: { data: Output } = await fal.subscribe('fal-ai/wan-effects', { input });
+    console.log(result.data);
+    return result.data;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error('FAL example failed:', message);
+    throw err;
+  }
+}
+
+async function main() {
+  await run();
+}
+if (import.meta.main) { void main(); }

--- a/examples/wzrdtech/typescript/src/generated/image-to-video/fal-ai__wan-pro__image-to-video.ts
+++ b/examples/wzrdtech/typescript/src/generated/image-to-video/fal-ai__wan-pro__image-to-video.ts
@@ -1,0 +1,40 @@
+/**
+ * Model: Wan-2.1 Pro Image-to-Video | Slug: fal-ai/wan-pro/image-to-video | Category: image-to-video | https://fal.ai/models/fal-ai/wan-pro/image-to-video
+ * Wan-2.1 Pro is a premium image-to-video model that generates high-quality video from a single image prompt, delivering exceptional visual quality and motion diversity from images
+ */
+import 'dotenv/config';
+import { fal } from '@fal-ai/client';
+
+if (!process.env.FAL_KEY) {
+  throw new Error('Missing FAL_KEY. Copy .env.example to .env and set your key.');
+}
+fal.config({ credentials: process.env.FAL_KEY! });
+
+interface Input {
+  prompt: string;
+  image_url: string;
+}
+type Output = unknown;
+
+export async function run(customInput?: Partial<Input>) {
+  const input: Input = {
+    prompt: "The whit...of determination",
+    image_url: "https://example.com/input.jpg",
+    ...customInput
+  } as Input;
+
+  try {
+    const result: { data: Output } = await fal.subscribe('fal-ai/wan-pro/image-to-video', { input });
+    console.log(result.data);
+    return result.data;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error('FAL example failed:', message);
+    throw err;
+  }
+}
+
+async function main() {
+  await run();
+}
+if (import.meta.main) { void main(); }

--- a/examples/wzrdtech/typescript/src/generated/text-to-audio/fal-ai__minimax-music__v1.5.ts
+++ b/examples/wzrdtech/typescript/src/generated/text-to-audio/fal-ai__minimax-music__v1.5.ts
@@ -1,0 +1,38 @@
+/**
+ * Model: MiniMax Music v1.5 | Slug: fal-ai/minimax-music/v1.5 | Category: text-to-audio | https://fal.ai/models/fal-ai/minimax-music/v1.5
+ * 
+ */
+import 'dotenv/config';
+import { fal } from '@fal-ai/client';
+
+if (!process.env.FAL_KEY) {
+  throw new Error('Missing FAL_KEY. Copy .env.example to .env and set your key.');
+}
+fal.config({ credentials: process.env.FAL_KEY! });
+
+interface Input {
+  prompt: string;
+}
+type Output = unknown;
+
+export async function run(customInput?: Partial<Input>) {
+  const input: Input = {
+    prompt: "A beautiful sunset over the mountains",
+    ...customInput
+  } as Input;
+
+  try {
+    const result: { data: Output } = await fal.subscribe('fal-ai/minimax-music/v1.5', { input });
+    console.log(result.data);
+    return result.data;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error('FAL example failed:', message);
+    throw err;
+  }
+}
+
+async function main() {
+  await run();
+}
+if (import.meta.main) { void main(); }

--- a/examples/wzrdtech/typescript/src/generated/text-to-audio/fal-ai__playai__tts__dialog.ts
+++ b/examples/wzrdtech/typescript/src/generated/text-to-audio/fal-ai__playai__tts__dialog.ts
@@ -1,0 +1,38 @@
+/**
+ * Model: PlayAI TTS Dialog | Slug: fal-ai/playai/tts/dialog | Category: text-to-audio | https://fal.ai/models/fal-ai/playai/tts/dialog
+ * 
+ */
+import 'dotenv/config';
+import { fal } from '@fal-ai/client';
+
+if (!process.env.FAL_KEY) {
+  throw new Error('Missing FAL_KEY. Copy .env.example to .env and set your key.');
+}
+fal.config({ credentials: process.env.FAL_KEY! });
+
+interface Input {
+  prompt: string;
+}
+type Output = unknown;
+
+export async function run(customInput?: Partial<Input>) {
+  const input: Input = {
+    prompt: "A beautiful sunset over the mountains",
+    ...customInput
+  } as Input;
+
+  try {
+    const result: { data: Output } = await fal.subscribe('fal-ai/playai/tts/dialog', { input });
+    console.log(result.data);
+    return result.data;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error('FAL example failed:', message);
+    throw err;
+  }
+}
+
+async function main() {
+  await run();
+}
+if (import.meta.main) { void main(); }

--- a/examples/wzrdtech/typescript/src/generated/text-to-image/bria__text-to-image__3.2.ts
+++ b/examples/wzrdtech/typescript/src/generated/text-to-image/bria__text-to-image__3.2.ts
@@ -1,0 +1,38 @@
+/**
+ * Model: Bria 3.2 Text-to-Image | Slug: bria/text-to-image/3.2 | Category: text-to-image | https://fal.ai/models/bria/text-to-image/3.2
+ * Bria’s 3.2 T2I model focuses on photorealistic synthesis with strong control over styles and lighting.
+ */
+import 'dotenv/config';
+import { fal } from '@fal-ai/client';
+
+if (!process.env.FAL_KEY) {
+  throw new Error('Missing FAL_KEY. Copy .env.example to .env and set your key.');
+}
+fal.config({ credentials: process.env.FAL_KEY! });
+
+interface Input {
+  prompt: string;
+}
+type Output = unknown;
+
+export async function run(customInput?: Partial<Input>) {
+  const input: Input = {
+    prompt: "A beautiful sunset over the mountains",
+    ...customInput
+  } as Input;
+
+  try {
+    const result: { data: Output } = await fal.subscribe('bria/text-to-image/3.2', { input });
+    console.log(result.data);
+    return result.data;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error('FAL example failed:', message);
+    throw err;
+  }
+}
+
+async function main() {
+  await run();
+}
+if (import.meta.main) { void main(); }

--- a/examples/wzrdtech/typescript/src/generated/text-to-image/fal-ai__flux-pro__v1.1-ultra.ts
+++ b/examples/wzrdtech/typescript/src/generated/text-to-image/fal-ai__flux-pro__v1.1-ultra.ts
@@ -1,0 +1,38 @@
+/**
+ * Model: FLUX.1 [pro] v1.1 Ultra | Slug: fal-ai/flux-pro/v1.1-ultra | Category: text-to-image | https://fal.ai/models/fal-ai/flux-pro/v1.1-ultra
+ * 
+ */
+import 'dotenv/config';
+import { fal } from '@fal-ai/client';
+
+if (!process.env.FAL_KEY) {
+  throw new Error('Missing FAL_KEY. Copy .env.example to .env and set your key.');
+}
+fal.config({ credentials: process.env.FAL_KEY! });
+
+interface Input {
+  prompt: string;
+}
+type Output = unknown;
+
+export async function run(customInput?: Partial<Input>) {
+  const input: Input = {
+    prompt: "A beautiful sunset over the mountains",
+    ...customInput
+  } as Input;
+
+  try {
+    const result: { data: Output } = await fal.subscribe('fal-ai/flux-pro/v1.1-ultra', { input });
+    console.log(result.data);
+    return result.data;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error('FAL example failed:', message);
+    throw err;
+  }
+}
+
+async function main() {
+  await run();
+}
+if (import.meta.main) { void main(); }

--- a/examples/wzrdtech/typescript/src/generated/text-to-image/fal-ai__hidream__i1__dev.ts
+++ b/examples/wzrdtech/typescript/src/generated/text-to-image/fal-ai__hidream__i1__dev.ts
@@ -1,0 +1,38 @@
+/**
+ * Model: Hidream I1 Dev | Slug: fal-ai/hidream/i1/dev | Category: text-to-image | https://fal.ai/models/fal-ai/hidream/i1/dev
+ * Developer-tuned HiDream I1 Dev with faster sampling and reduced cost for iteration loops.
+ */
+import 'dotenv/config';
+import { fal } from '@fal-ai/client';
+
+if (!process.env.FAL_KEY) {
+  throw new Error('Missing FAL_KEY. Copy .env.example to .env and set your key.');
+}
+fal.config({ credentials: process.env.FAL_KEY! });
+
+interface Input {
+  prompt: string;
+}
+type Output = unknown;
+
+export async function run(customInput?: Partial<Input>) {
+  const input: Input = {
+    prompt: "A beautiful sunset over the mountains",
+    ...customInput
+  } as Input;
+
+  try {
+    const result: { data: Output } = await fal.subscribe('fal-ai/hidream/i1/dev', { input });
+    console.log(result.data);
+    return result.data;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error('FAL example failed:', message);
+    throw err;
+  }
+}
+
+async function main() {
+  await run();
+}
+if (import.meta.main) { void main(); }

--- a/examples/wzrdtech/typescript/src/generated/text-to-image/fal-ai__hidream__i1__full.ts
+++ b/examples/wzrdtech/typescript/src/generated/text-to-image/fal-ai__hidream__i1__full.ts
@@ -1,0 +1,38 @@
+/**
+ * Model: Hidream I1 Full | Slug: fal-ai/hidream/i1/full | Category: text-to-image | https://fal.ai/models/fal-ai/hidream/i1/full
+ * HiDream I1 Full is a text-to-image model offering high-resolution synthesis with stylistic diversity.
+ */
+import 'dotenv/config';
+import { fal } from '@fal-ai/client';
+
+if (!process.env.FAL_KEY) {
+  throw new Error('Missing FAL_KEY. Copy .env.example to .env and set your key.');
+}
+fal.config({ credentials: process.env.FAL_KEY! });
+
+interface Input {
+  prompt: string;
+}
+type Output = unknown;
+
+export async function run(customInput?: Partial<Input>) {
+  const input: Input = {
+    prompt: "A beautiful sunset over the mountains",
+    ...customInput
+  } as Input;
+
+  try {
+    const result: { data: Output } = await fal.subscribe('fal-ai/hidream/i1/full', { input });
+    console.log(result.data);
+    return result.data;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error('FAL example failed:', message);
+    throw err;
+  }
+}
+
+async function main() {
+  await run();
+}
+if (import.meta.main) { void main(); }

--- a/examples/wzrdtech/typescript/src/generated/text-to-image/fal-ai__imagen4.ts
+++ b/examples/wzrdtech/typescript/src/generated/text-to-image/fal-ai__imagen4.ts
@@ -1,0 +1,38 @@
+/**
+ * Model: Imagen 4 | Slug: fal-ai/imagen4 | Category: text-to-image | https://fal.ai/models/fal-ai/imagen4
+ * Latest Imagen-4 text-to-image baseline with photorealistic rendering capabilities and style control.
+ */
+import 'dotenv/config';
+import { fal } from '@fal-ai/client';
+
+if (!process.env.FAL_KEY) {
+  throw new Error('Missing FAL_KEY. Copy .env.example to .env and set your key.');
+}
+fal.config({ credentials: process.env.FAL_KEY! });
+
+interface Input {
+  prompt: string;
+}
+type Output = unknown;
+
+export async function run(customInput?: Partial<Input>) {
+  const input: Input = {
+    prompt: "A beautiful sunset over the mountains",
+    ...customInput
+  } as Input;
+
+  try {
+    const result: { data: Output } = await fal.subscribe('fal-ai/imagen4', { input });
+    console.log(result.data);
+    return result.data;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error('FAL example failed:', message);
+    throw err;
+  }
+}
+
+async function main() {
+  await run();
+}
+if (import.meta.main) { void main(); }

--- a/examples/wzrdtech/typescript/src/generated/text-to-image/fal-ai__imagen4__preview__fast.ts
+++ b/examples/wzrdtech/typescript/src/generated/text-to-image/fal-ai__imagen4__preview__fast.ts
@@ -1,0 +1,38 @@
+/**
+ * Model: Imagen 4 | Slug: fal-ai/imagen4/preview/fast | Category: text-to-image | https://fal.ai/models/fal-ai/imagen4/preview/fast
+ * Fast preview tier for Imagen 4, trading some fidelity for speed.
+ */
+import 'dotenv/config';
+import { fal } from '@fal-ai/client';
+
+if (!process.env.FAL_KEY) {
+  throw new Error('Missing FAL_KEY. Copy .env.example to .env and set your key.');
+}
+fal.config({ credentials: process.env.FAL_KEY! });
+
+interface Input {
+  prompt: string;
+}
+type Output = unknown;
+
+export async function run(customInput?: Partial<Input>) {
+  const input: Input = {
+    prompt: "A beautiful sunset over the mountains",
+    ...customInput
+  } as Input;
+
+  try {
+    const result: { data: Output } = await fal.subscribe('fal-ai/imagen4/preview/fast', { input });
+    console.log(result.data);
+    return result.data;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error('FAL example failed:', message);
+    throw err;
+  }
+}
+
+async function main() {
+  await run();
+}
+if (import.meta.main) { void main(); }

--- a/examples/wzrdtech/typescript/src/generated/text-to-image/fal-ai__recraft__v3__text-to-image.ts
+++ b/examples/wzrdtech/typescript/src/generated/text-to-image/fal-ai__recraft__v3__text-to-image.ts
@@ -1,0 +1,38 @@
+/**
+ * Model: Recraft v3 Text-to-Image | Slug: fal-ai/recraft/v3/text-to-image | Category: text-to-image | https://fal.ai/models/fal-ai/recraft/v3/text-to-image
+ * 
+ */
+import 'dotenv/config';
+import { fal } from '@fal-ai/client';
+
+if (!process.env.FAL_KEY) {
+  throw new Error('Missing FAL_KEY. Copy .env.example to .env and set your key.');
+}
+fal.config({ credentials: process.env.FAL_KEY! });
+
+interface Input {
+  prompt: string;
+}
+type Output = unknown;
+
+export async function run(customInput?: Partial<Input>) {
+  const input: Input = {
+    prompt: "A beautiful sunset over the mountains",
+    ...customInput
+  } as Input;
+
+  try {
+    const result: { data: Output } = await fal.subscribe('fal-ai/recraft/v3/text-to-image', { input });
+    console.log(result.data);
+    return result.data;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error('FAL example failed:', message);
+    throw err;
+  }
+}
+
+async function main() {
+  await run();
+}
+if (import.meta.main) { void main(); }

--- a/examples/wzrdtech/typescript/src/generated/text-to-video/fal-ai__kling-video__v2.0__master__text-to-video.ts
+++ b/examples/wzrdtech/typescript/src/generated/text-to-video/fal-ai__kling-video__v2.0__master__text-to-video.ts
@@ -1,0 +1,38 @@
+/**
+ * Model: Kling 2.0 Master (Text-to-Video) | Slug: fal-ai/kling-video/v2.0/master/text-to-video | Category: text-to-video | https://fal.ai/models/fal-ai/kling-video/v2.0/master/text-to-video
+ * Master-tier Kling text-to-video with rich motion synthesis and scene depth.
+ */
+import 'dotenv/config';
+import { fal } from '@fal-ai/client';
+
+if (!process.env.FAL_KEY) {
+  throw new Error('Missing FAL_KEY. Copy .env.example to .env and set your key.');
+}
+fal.config({ credentials: process.env.FAL_KEY! });
+
+interface Input {
+  prompt: string;
+}
+type Output = unknown;
+
+export async function run(customInput?: Partial<Input>) {
+  const input: Input = {
+    prompt: "A beautiful sunset over the mountains",
+    ...customInput
+  } as Input;
+
+  try {
+    const result: { data: Output } = await fal.subscribe('fal-ai/kling-video/v2.0/master/text-to-video', { input });
+    console.log(result.data);
+    return result.data;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error('FAL example failed:', message);
+    throw err;
+  }
+}
+
+async function main() {
+  await run();
+}
+if (import.meta.main) { void main(); }

--- a/examples/wzrdtech/typescript/src/generated/text-to-video/fal-ai__kling-video__v2.5-turbo__pro__text-to-video.ts
+++ b/examples/wzrdtech/typescript/src/generated/text-to-video/fal-ai__kling-video__v2.5-turbo__pro__text-to-video.ts
@@ -1,0 +1,38 @@
+/**
+ * Model: Kling Video v2.5 Turbo Pro (Text-to-Video) | Slug: fal-ai/kling-video/v2.5-turbo/pro/text-to-video | Category: text-to-video | https://fal.ai/models/fal-ai/kling-video/v2.5-turbo/pro/text-to-video
+ * 
+ */
+import 'dotenv/config';
+import { fal } from '@fal-ai/client';
+
+if (!process.env.FAL_KEY) {
+  throw new Error('Missing FAL_KEY. Copy .env.example to .env and set your key.');
+}
+fal.config({ credentials: process.env.FAL_KEY! });
+
+interface Input {
+  prompt: string;
+}
+type Output = unknown;
+
+export async function run(customInput?: Partial<Input>) {
+  const input: Input = {
+    prompt: "A beautiful sunset over the mountains",
+    ...customInput
+  } as Input;
+
+  try {
+    const result: { data: Output } = await fal.subscribe('fal-ai/kling-video/v2.5-turbo/pro/text-to-video', { input });
+    console.log(result.data);
+    return result.data;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error('FAL example failed:', message);
+    throw err;
+  }
+}
+
+async function main() {
+  await run();
+}
+if (import.meta.main) { void main(); }

--- a/examples/wzrdtech/typescript/src/generated/text-to-video/fal-ai__minimax__hailuo-02__standard__text-to-video.ts
+++ b/examples/wzrdtech/typescript/src/generated/text-to-video/fal-ai__minimax__hailuo-02__standard__text-to-video.ts
@@ -1,0 +1,38 @@
+/**
+ * Model: MiniMax Hailuo 02 [Standard] (Text to Video) | Slug: fal-ai/minimax/hailuo-02/standard/text-to-video | Category: text-to-video | https://fal.ai/models/fal-ai/minimax/hailuo-02/standard/text-to-video
+ * Text-to-video generation with Hailuo 02 (Standard), emphasizing narrative motion and scene coherence.
+ */
+import 'dotenv/config';
+import { fal } from '@fal-ai/client';
+
+if (!process.env.FAL_KEY) {
+  throw new Error('Missing FAL_KEY. Copy .env.example to .env and set your key.');
+}
+fal.config({ credentials: process.env.FAL_KEY! });
+
+interface Input {
+  prompt: string;
+}
+type Output = unknown;
+
+export async function run(customInput?: Partial<Input>) {
+  const input: Input = {
+    prompt: "A beautiful sunset over the mountains",
+    ...customInput
+  } as Input;
+
+  try {
+    const result: { data: Output } = await fal.subscribe('fal-ai/minimax/hailuo-02/standard/text-to-video', { input });
+    console.log(result.data);
+    return result.data;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error('FAL example failed:', message);
+    throw err;
+  }
+}
+
+async function main() {
+  await run();
+}
+if (import.meta.main) { void main(); }

--- a/examples/wzrdtech/typescript/src/generated/text-to-video/fal-ai__veo3.ts
+++ b/examples/wzrdtech/typescript/src/generated/text-to-video/fal-ai__veo3.ts
@@ -1,0 +1,38 @@
+/**
+ * Model: Veo 3 | Slug: fal-ai/veo3 | Category: text-to-video | https://fal.ai/models/fal-ai/veo3
+ * Veo 3 provides fast, controllable text-to-video synthesis for short, coherent clips.
+ */
+import 'dotenv/config';
+import { fal } from '@fal-ai/client';
+
+if (!process.env.FAL_KEY) {
+  throw new Error('Missing FAL_KEY. Copy .env.example to .env and set your key.');
+}
+fal.config({ credentials: process.env.FAL_KEY! });
+
+interface Input {
+  prompt: string;
+}
+type Output = unknown;
+
+export async function run(customInput?: Partial<Input>) {
+  const input: Input = {
+    prompt: "A beautiful sunset over the mountains",
+    ...customInput
+  } as Input;
+
+  try {
+    const result: { data: Output } = await fal.subscribe('fal-ai/veo3', { input });
+    console.log(result.data);
+    return result.data;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error('FAL example failed:', message);
+    throw err;
+  }
+}
+
+async function main() {
+  await run();
+}
+if (import.meta.main) { void main(); }

--- a/examples/wzrdtech/typescript/src/generated/text-to-video/fal-ai__veo3__fast.ts
+++ b/examples/wzrdtech/typescript/src/generated/text-to-video/fal-ai__veo3__fast.ts
@@ -1,0 +1,38 @@
+/**
+ * Model: Veo 3 Fast (Text-to-Video) | Slug: fal-ai/veo3/fast | Category: text-to-video | https://fal.ai/models/fal-ai/veo3/fast
+ * 
+ */
+import 'dotenv/config';
+import { fal } from '@fal-ai/client';
+
+if (!process.env.FAL_KEY) {
+  throw new Error('Missing FAL_KEY. Copy .env.example to .env and set your key.');
+}
+fal.config({ credentials: process.env.FAL_KEY! });
+
+interface Input {
+  prompt: string;
+}
+type Output = unknown;
+
+export async function run(customInput?: Partial<Input>) {
+  const input: Input = {
+    prompt: "A beautiful sunset over the mountains",
+    ...customInput
+  } as Input;
+
+  try {
+    const result: { data: Output } = await fal.subscribe('fal-ai/veo3/fast', { input });
+    console.log(result.data);
+    return result.data;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error('FAL example failed:', message);
+    throw err;
+  }
+}
+
+async function main() {
+  await run();
+}
+if (import.meta.main) { void main(); }

--- a/examples/wzrdtech/typescript/src/generated/training/fal-ai__flux-kontext-trainer.ts
+++ b/examples/wzrdtech/typescript/src/generated/training/fal-ai__flux-kontext-trainer.ts
@@ -1,0 +1,35 @@
+/**
+ * Model: Flux Kontext Trainer | Slug: fal-ai/flux-kontext-trainer | Category: training | https://fal.ai/models/fal-ai/flux-kontext-trainer
+ * Train a Kontext-flavored Flux adapter for style-consistent image transformations.
+ */
+import 'dotenv/config';
+import { fal } from '@fal-ai/client';
+
+if (!process.env.FAL_KEY) {
+  throw new Error('Missing FAL_KEY. Copy .env.example to .env and set your key.');
+}
+fal.config({ credentials: process.env.FAL_KEY! });
+
+type Input = Record<string, unknown>;
+type Output = unknown;
+
+export async function run(customInput?: Partial<Input>) {
+  const input: Input = {
+    ...customInput
+  } as Input;
+
+  try {
+    const result: { data: Output } = await fal.subscribe('fal-ai/flux-kontext-trainer', { input });
+    console.log(result.data);
+    return result.data;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error('FAL example failed:', message);
+    throw err;
+  }
+}
+
+async function main() {
+  await run();
+}
+if (import.meta.main) { void main(); }

--- a/examples/wzrdtech/typescript/src/generated/training/fal-ai__flux-krea-trainer.ts
+++ b/examples/wzrdtech/typescript/src/generated/training/fal-ai__flux-krea-trainer.ts
@@ -1,0 +1,35 @@
+/**
+ * Model: Train Flux Krea LoRA | Slug: fal-ai/flux-krea-trainer | Category: training | https://fal.ai/models/fal-ai/flux-krea-trainer
+ * Train a LoRA adapter for Flux using Krea datasets to personalize image generation.
+ */
+import 'dotenv/config';
+import { fal } from '@fal-ai/client';
+
+if (!process.env.FAL_KEY) {
+  throw new Error('Missing FAL_KEY. Copy .env.example to .env and set your key.');
+}
+fal.config({ credentials: process.env.FAL_KEY! });
+
+type Input = Record<string, unknown>;
+type Output = unknown;
+
+export async function run(customInput?: Partial<Input>) {
+  const input: Input = {
+    ...customInput
+  } as Input;
+
+  try {
+    const result: { data: Output } = await fal.subscribe('fal-ai/flux-krea-trainer', { input });
+    console.log(result.data);
+    return result.data;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error('FAL example failed:', message);
+    throw err;
+  }
+}
+
+async function main() {
+  await run();
+}
+if (import.meta.main) { void main(); }

--- a/examples/wzrdtech/typescript/src/generated/video-to-video/bria__video__background-removal.ts
+++ b/examples/wzrdtech/typescript/src/generated/video-to-video/bria__video__background-removal.ts
@@ -1,0 +1,40 @@
+/**
+ * Model: Bria Video Background Removal | Slug: bria/video/background-removal | Category: video-to-video | https://fal.ai/models/bria/video/background-removal
+ * 
+ */
+import 'dotenv/config';
+import { fal } from '@fal-ai/client';
+
+if (!process.env.FAL_KEY) {
+  throw new Error('Missing FAL_KEY. Copy .env.example to .env and set your key.');
+}
+fal.config({ credentials: process.env.FAL_KEY! });
+
+interface Input {
+  prompt: string;
+  image_url: string;
+}
+type Output = unknown;
+
+export async function run(customInput?: Partial<Input>) {
+  const input: Input = {
+    prompt: "The whit...of determination",
+    image_url: "https://example.com/input.jpg",
+    ...customInput
+  } as Input;
+
+  try {
+    const result: { data: Output } = await fal.subscribe('bria/video/background-removal', { input });
+    console.log(result.data);
+    return result.data;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error('FAL example failed:', message);
+    throw err;
+  }
+}
+
+async function main() {
+  await run();
+}
+if (import.meta.main) { void main(); }

--- a/examples/wzrdtech/typescript/src/generated/video-to-video/fal-ai__mmaudio-v2.ts
+++ b/examples/wzrdtech/typescript/src/generated/video-to-video/fal-ai__mmaudio-v2.ts
@@ -1,0 +1,40 @@
+/**
+ * Model: MMAudio v2 (Video-to-Video) | Slug: fal-ai/mmaudio-v2 | Category: video-to-video | https://fal.ai/models/fal-ai/mmaudio-v2
+ * 
+ */
+import 'dotenv/config';
+import { fal } from '@fal-ai/client';
+
+if (!process.env.FAL_KEY) {
+  throw new Error('Missing FAL_KEY. Copy .env.example to .env and set your key.');
+}
+fal.config({ credentials: process.env.FAL_KEY! });
+
+interface Input {
+  prompt: string;
+  image_url: string;
+}
+type Output = unknown;
+
+export async function run(customInput?: Partial<Input>) {
+  const input: Input = {
+    prompt: "The whit...of determination",
+    image_url: "https://example.com/input.jpg",
+    ...customInput
+  } as Input;
+
+  try {
+    const result: { data: Output } = await fal.subscribe('fal-ai/mmaudio-v2', { input });
+    console.log(result.data);
+    return result.data;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error('FAL example failed:', message);
+    throw err;
+  }
+}
+
+async function main() {
+  await run();
+}
+if (import.meta.main) { void main(); }

--- a/examples/wzrdtech/typescript/src/index.ts
+++ b/examples/wzrdtech/typescript/src/index.ts
@@ -1,0 +1,104 @@
+import 'dotenv/config';
+import * as fal_ai__flux_pro__kontext from './generated/image-to-image/fal-ai__flux-pro__kontext.ts';
+import * as fal_ai__flux__dev__image_to_image from './generated/image-to-image/fal-ai__flux__dev__image-to-image.ts';
+import * as fal_ai__flux_pro__v1_1_ultra from './generated/text-to-image/fal-ai__flux-pro__v1.1-ultra.ts';
+import * as fal_ai__recraft__v3__text_to_image from './generated/text-to-image/fal-ai__recraft__v3__text-to-image.ts';
+import * as fal_ai__kling_video__v2__master__image_to_video from './generated/image-to-video/fal-ai__kling-video__v2__master__image-to-video.ts';
+import * as fal_ai__wan_effects from './generated/image-to-video/fal-ai__wan-effects.ts';
+import * as fal_ai__kling_video__v2_5_turbo__pro__text_to_video from './generated/text-to-video/fal-ai__kling-video__v2.5-turbo__pro__text-to-video.ts';
+import * as fal_ai__veo3__fast from './generated/text-to-video/fal-ai__veo3__fast.ts';
+import * as fal_ai__wan_pro__image_to_video from './generated/image-to-video/fal-ai__wan-pro__image-to-video.ts';
+import * as fal_ai__veo2__image_to_video from './generated/image-to-video/fal-ai__veo2__image-to-video.ts';
+import * as fal_ai__kling_video__v1_6__pro__image_to_video from './generated/image-to-video/fal-ai__kling-video__v1.6__pro__image-to-video.ts';
+import * as fal_ai__minimax__video_01__image_to_video from './generated/image-to-video/fal-ai__minimax__video-01__image-to-video.ts';
+import * as fal_ai__wan_25_preview__image_to_video from './generated/image-to-video/fal-ai__wan-25-preview__image-to-video.ts';
+import * as fal_ai__kling_video__v2_5_turbo__pro__image_to_video from './generated/image-to-video/fal-ai__kling-video__v2.5-turbo__pro__image-to-video.ts';
+import * as fal_ai__flux_krea_trainer from './generated/training/fal-ai__flux-krea-trainer.ts';
+import * as fal_ai__flux_kontext_trainer from './generated/training/fal-ai__flux-kontext-trainer.ts';
+import * as fal_ai__minimax__hailuo_02__standard__image_to_video from './generated/image-to-video/fal-ai__minimax__hailuo-02__standard__image-to-video.ts';
+import * as fal_ai__minimax__hailuo_02__standard__text_to_video from './generated/text-to-video/fal-ai__minimax__hailuo-02__standard__text-to-video.ts';
+import * as bria__text_to_image__3_2 from './generated/text-to-image/bria__text-to-image__3.2.ts';
+import * as fal_ai__bytedance__seedance__v1__pro__image_to_video from './generated/image-to-video/fal-ai__bytedance__seedance__v1__pro__image-to-video.ts';
+import * as fal_ai__imagen4__preview__fast from './generated/text-to-image/fal-ai__imagen4__preview__fast.ts';
+import * as fal_ai__veo3 from './generated/text-to-video/fal-ai__veo3.ts';
+import * as fal_ai__kling_video__v2_1__master__image_to_video from './generated/image-to-video/fal-ai__kling-video__v2.1__master__image-to-video.ts';
+import * as fal_ai__kling_video__v2_1__image_to_video from './generated/image-to-video/fal-ai__kling-video__v2.1__image-to-video.ts';
+import * as fal_ai__imagen4 from './generated/text-to-image/fal-ai__imagen4.ts';
+import * as fal_ai__kling_video__v2_0__master__text_to_video from './generated/text-to-video/fal-ai__kling-video__v2.0__master__text-to-video.ts';
+import * as fal_ai__hidream__i1__full from './generated/text-to-image/fal-ai__hidream__i1__full.ts';
+import * as fal_ai__hidream__i1__dev from './generated/text-to-image/fal-ai__hidream__i1__dev.ts';
+import * as bria__video__background_removal from './generated/video-to-video/bria__video__background-removal.ts';
+import * as fal_ai__mmaudio_v2 from './generated/video-to-video/fal-ai__mmaudio-v2.ts';
+import * as fal_ai__playai__tts__dialog from './generated/text-to-audio/fal-ai__playai__tts__dialog.ts';
+import * as fal_ai__minimax_music__v1_5 from './generated/text-to-audio/fal-ai__minimax-music__v1.5.ts';
+
+type Runner = (customInput?: Record<string, unknown>) => Promise<unknown>;
+
+const registry = new Map<string, Runner>([
+    ['fal-ai/flux-pro/kontext', fal_ai__flux_pro__kontext.run], // image-to-image
+    ['fal-ai/flux/dev/image-to-image', fal_ai__flux__dev__image_to_image.run], // image-to-image
+    ['fal-ai/flux-pro/v1.1-ultra', fal_ai__flux_pro__v1_1_ultra.run], // text-to-image
+    ['fal-ai/recraft/v3/text-to-image', fal_ai__recraft__v3__text_to_image.run], // text-to-image
+    ['fal-ai/kling-video/v2/master/image-to-video', fal_ai__kling_video__v2__master__image_to_video.run], // image-to-video
+    ['fal-ai/wan-effects', fal_ai__wan_effects.run], // image-to-video
+    ['fal-ai/kling-video/v2.5-turbo/pro/text-to-video', fal_ai__kling_video__v2_5_turbo__pro__text_to_video.run], // text-to-video
+    ['fal-ai/veo3/fast', fal_ai__veo3__fast.run], // text-to-video
+    ['fal-ai/wan-pro/image-to-video', fal_ai__wan_pro__image_to_video.run], // image-to-video
+    ['fal-ai/veo2/image-to-video', fal_ai__veo2__image_to_video.run], // image-to-video
+    ['fal-ai/kling-video/v1.6/pro/image-to-video', fal_ai__kling_video__v1_6__pro__image_to_video.run], // image-to-video
+    ['fal-ai/minimax/video-01/image-to-video', fal_ai__minimax__video_01__image_to_video.run], // image-to-video
+    ['fal-ai/wan-25-preview/image-to-video', fal_ai__wan_25_preview__image_to_video.run], // image-to-video
+    ['fal-ai/kling-video/v2.5-turbo/pro/image-to-video', fal_ai__kling_video__v2_5_turbo__pro__image_to_video.run], // image-to-video
+    ['fal-ai/flux-krea-trainer', fal_ai__flux_krea_trainer.run], // training
+    ['fal-ai/flux-kontext-trainer', fal_ai__flux_kontext_trainer.run], // training
+    ['fal-ai/minimax/hailuo-02/standard/image-to-video', fal_ai__minimax__hailuo_02__standard__image_to_video.run], // image-to-video
+    ['fal-ai/minimax/hailuo-02/standard/text-to-video', fal_ai__minimax__hailuo_02__standard__text_to_video.run], // text-to-video
+    ['bria/text-to-image/3.2', bria__text_to_image__3_2.run], // text-to-image
+    ['fal-ai/bytedance/seedance/v1/pro/image-to-video', fal_ai__bytedance__seedance__v1__pro__image_to_video.run], // image-to-video
+    ['fal-ai/imagen4/preview/fast', fal_ai__imagen4__preview__fast.run], // text-to-image
+    ['fal-ai/veo3', fal_ai__veo3.run], // text-to-video
+    ['fal-ai/kling-video/v2.1/master/image-to-video', fal_ai__kling_video__v2_1__master__image_to_video.run], // image-to-video
+    ['fal-ai/kling-video/v2.1/image-to-video', fal_ai__kling_video__v2_1__image_to_video.run], // image-to-video
+    ['fal-ai/imagen4', fal_ai__imagen4.run], // text-to-image
+    ['fal-ai/kling-video/v2.0/master/text-to-video', fal_ai__kling_video__v2_0__master__text_to_video.run], // text-to-video
+    ['fal-ai/hidream/i1/full', fal_ai__hidream__i1__full.run], // text-to-image
+    ['fal-ai/hidream/i1/dev', fal_ai__hidream__i1__dev.run], // text-to-image
+    ['bria/video/background-removal', bria__video__background_removal.run], // video-to-video
+    ['fal-ai/mmaudio-v2', fal_ai__mmaudio_v2.run], // video-to-video
+    ['fal-ai/playai/tts/dialog', fal_ai__playai__tts__dialog.run], // text-to-audio
+    ['fal-ai/minimax-music/v1.5', fal_ai__minimax_music__v1_5.run] // text-to-audio
+]);
+
+function help() {
+  console.log('Usage: ts-node src/index.ts --slug <slug>');
+  console.log('Available slugs:');
+  for (const [slug] of registry) {
+    console.log('  -', slug);
+  }
+}
+
+async function main() {
+  const args = new Map<string, string>();
+  for (let i=2; i<process.argv.length; i+=2) {
+    args.set(process.argv[i], process.argv[i+1]);
+  }
+  const slug = args.get('--slug');
+  if (!slug) {
+    help();
+    process.exit(1);
+  }
+  const run = registry.get(slug);
+  if (!run) {
+    console.error('Unknown slug:', slug);
+    help();
+    process.exit(1);
+  }
+  const result = await run();
+  if (result !== undefined) {
+    console.log(JSON.stringify(result, null, 2));
+  }
+}
+
+if (import.meta.main) {
+  void main();
+}

--- a/examples/wzrdtech/typescript/test/typecheck.test.ts
+++ b/examples/wzrdtech/typescript/test/typecheck.test.ts
@@ -1,0 +1,11 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+describe('typecheck only', () => {
+  it('generated files exist', () => {
+    const base = path.resolve(__dirname, '../src/generated');
+    assert.ok(fs.existsSync(base));
+  });
+});

--- a/examples/wzrdtech/typescript/tsconfig.json
+++ b/examples/wzrdtech/typescript/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts"]
+}


### PR DESCRIPTION
<!-- x402: deterministic structure & naming, strict TS types, idempotent file writes. -->
<!-- ACP: no secrets in source; FAL_KEY must come from env; minimal logging; network only to FAL during explicit runs. -->
## Summary
- rename the TypeScript example workspace to `examples/wzrdtech/typescript` and refresh docs to point at the new filter path and slug list
- expand the CLI registry with additional wzrdtech model runners spanning image/video generation and training, backed by the new generated modules

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68faa6eab094832fb5d09ff20264a53c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a TypeScript examples project with CLI support for running various AI generation modules.

* **Documentation**
  * Added Quick start guide with setup instructions and environment configuration details.

* **Tests**
  * Added validation test to verify generated files exist.

* **Chores**
  * Added project configuration files including package metadata, TypeScript settings, and environment setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->