### PR TITLE
Address idempotency replay and payment completion issues

### DIFF
--- a/src/routes/payment.ts
+++ b/src/routes/payment.ts
@@ -28,7 +28,7 @@ export function createPaymentRouter(paymentService: PaymentService, merchantServ
     try {
       const { payment_intent_id, session_id } = req.body;
       const intent = await paymentService.confirmIntent(payment_intent_id);
-      if (session_id) {
+      if (session_id && intent.status === 'succeeded') {
         await merchantService.markCompleted(session_id);
       }
       res.json(


### PR DESCRIPTION
## Summary
- preserve original status and headers when replaying cached idempotent responses
- capture response metadata during initial request storage
- prevent marking merchant sessions complete when payment confirmation does not succeed

## Testing
- npm run lint *(fails: existing type errors in rate limit and merchant session services)*

------
https://chatgpt.com/codex/tasks/task_e_68fab2fdac58832fa902355daf55ea34