### PR TITLE
docs: clarify TypeScript example dependency install

### DIFF
--- a/examples/wzrdtech/typescript/README.md
+++ b/examples/wzrdtech/typescript/README.md
@@ -4,6 +4,7 @@
 ```bash
 pnpm i # or npm/yarn
 cp .env.example .env && edit .env
+pnpm --filter ./examples/wzrdtech/typescript install
 pnpm --filter ./examples/wzrdtech/typescript build
 pnpm --filter ./examples/wzrdtech/typescript examples -- --slug <one-of-the-slugs-below>
 


### PR DESCRIPTION
## Summary
- add an explicit install step for the TypeScript example package before running its scripts so the dependencies are available

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fab2f4df44832fa99294c39a19beb1