### PR TITLE
Fix fal TypeScript examples script for ESM execution

### DIFF
--- a/examples/fal/typescript/package.json
+++ b/examples/fal/typescript/package.json
@@ -5,7 +5,7 @@
   "version": "0.1.0",
   "scripts": {
     "build": "tsc -p tsconfig.json --noEmit",
-    "examples": "ts-node src/index.ts",
+    "examples": "node --loader ts-node/esm src/index.ts",
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- update the `examples` npm script to launch `ts-node` via Node's ESM loader so it matches the package's `type: module`

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fab2f12964832fbc4bb886b0230e1b